### PR TITLE
Add keep service option

### DIFF
--- a/cmd/ecs-deploy/main.go
+++ b/cmd/ecs-deploy/main.go
@@ -11,16 +11,17 @@ var version string
 
 func main() {
 	var (
-		cluster   = kingpin.Flag("cluster", "Set cluster name").Required().String()
-		service   = kingpin.Flag("service", "Set service name").Required().String()
-		container = kingpin.Flag("container", "Set container name").Required().String()
-		image     = kingpin.Flag("image", "Set image").Required().String()
+		cluster     = kingpin.Flag("cluster", "Set cluster name").Required().String()
+		service     = kingpin.Flag("service", "Set service name").Required().String()
+		container   = kingpin.Flag("container", "Set container name").Required().String()
+		image       = kingpin.Flag("image", "Set image").Required().String()
+		keepService = kingpin.Flag("keep-service", "Not update service").Bool()
 	)
 
 	kingpin.Version(version)
 	kingpin.Parse()
 
-	err := ecsdeploy.Run(*cluster, *service, *container, *image)
+	err := ecsdeploy.Run(*cluster, *service, *container, *image, *keepService)
 
 	if err != nil {
 		fmt.Println("error:", err)

--- a/ecsdeploy.go
+++ b/ecsdeploy.go
@@ -8,7 +8,7 @@ import (
 	"log"
 )
 
-func Run(cluster string, service string, container string, image string) error {
+func Run(cluster string, service string, container string, image string, keepService bool) error {
 	sess, err := session.NewSession()
 
 	if err != nil {
@@ -43,12 +43,14 @@ func Run(cluster string, service string, container string, image string) error {
 		log.Println("Registered TaskDefinition with new image: ", *newTask.TaskDefinition.TaskDefinitionArn)
 	}
 
-	resp, err := UpdateService(svc, *newTask.TaskDefinition, cluster, service)
+	if keepService == false {
+		resp, err := UpdateService(svc, *newTask.TaskDefinition, cluster, service)
 
-	if err != nil {
-		return err
-	} else {
-		log.Println("Updated service: ", *resp.Service.TaskDefinition)
+		if err != nil {
+			return err
+		} else {
+			log.Println("Updated service: ", *resp.Service.TaskDefinition)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Adds an option new `--keep-service` which not update service.
Useful when control update service by manual operation.

サービス更新を行わない `--keep-service` オプションを追加しました。
サービス更新を手動で制御する場合に使用します。
