### PR TITLE
Change use task definition latest active version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ $ export AWS_SECRET_ACCESS_KEY=
 $ ecs-deploy \
   --cluster=<cluster-name> \
   --service=<service-name> \
-  --task-family=<task-family>
+  --task-family=<task-family> \
   --container=<container-name> \
-  --image=<new image> \
+  --image=<new image>
 ```
 
 ## Help

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ $ export AWS_SECRET_ACCESS_KEY=
 $ ecs-deploy \
   --cluster=<cluster-name> \
   --service=<service-name> \
+  --task-family=<task-family>
   --container=<container-name> \
-  --image=<new image> 
+  --image=<new image> \
 ```
 
 ## Help
@@ -24,9 +25,12 @@ usage: ecs-deploy --cluster=CLUSTER --service=SERVICE --container=CONTAINER --im
 
 Flags:
   --help                 Show context-sensitive help (also try --help-long and --help-man).
-  --cluster=CLUSTER      Set cluster name
-  --service=SERVICE      Set service name
-  --container=CONTAINER  Set container name
-  --image=IMAGE          Set image
-  --version              Show application version.
+  --cluster=CLUSTER          Set cluster name
+  --service=SERVICE          Set service name
+  --task-family=TASK-FAMILY  Set task definition family
+  --container=CONTAINER      Set container name
+  --image=IMAGE              Set image
+  --keep-service             Not update service
+  --version                  Show application version.
+  --help                     Show context-sensitive help (also try --help-long and --help-man).
 ```

--- a/cmd/ecs-deploy/main.go
+++ b/cmd/ecs-deploy/main.go
@@ -13,6 +13,7 @@ func main() {
 	var (
 		cluster     = kingpin.Flag("cluster", "Set cluster name").Required().String()
 		service     = kingpin.Flag("service", "Set service name").Required().String()
+		taskFamily  = kingpin.Flag("task-family", "Set task definition family").Required().String()
 		container   = kingpin.Flag("container", "Set container name").Required().String()
 		image       = kingpin.Flag("image", "Set image").Required().String()
 		keepService = kingpin.Flag("keep-service", "Not update service").Bool()
@@ -21,7 +22,7 @@ func main() {
 	kingpin.Version(version)
 	kingpin.Parse()
 
-	err := ecsdeploy.Run(*cluster, *service, *container, *image, *keepService)
+	err := ecsdeploy.Run(*cluster, *service, *taskFamily, *container, *image, *keepService)
 
 	if err != nil {
 		fmt.Println("error:", err)


### PR DESCRIPTION
- Adds an option new `--task-family` which specify task definistion
- Change service to reflect on task definition to create from family latest active version

### 日本語訳
- 使用するタスク定義を `--task-family` で指定するように変更
- サービスに反映するタスク定義を、ファミリーの最新のActiveから作成するように変更
